### PR TITLE
Remove marquee and related styles

### DIFF
--- a/home.html
+++ b/home.html
@@ -122,71 +122,9 @@
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; 
         }
         
-        /* Marquee Animation */
-        @keyframes marquee {
-            0% {
-                transform: translateX(0);
-            }
-            100% {
-                transform: translateX(-50%);
-            }
-        }
-        
-        .marquee-content {
-            animation: marquee 60s linear infinite;
-        }
     </style>
 </head>
-<body class="bg-black text-gray-100 sf-pro pt-[64px]">
-    <!-- Fixed Marquee Bar -->
-    <div class="fixed top-0 left-0 right-0 h-16 bg-white z-50 overflow-hidden">
-        <div class="h-full flex items-center">
-            <div class="marquee-container flex">
-                <div class="marquee-content flex items-center gap-6 text-black text-xl font-semibold whitespace-nowrap">
-                    <span>STORE PHOTOS AND VIDEOS</span>
-                    <span>·</span>
-                    <span>SAVE MONEY</span>
-                    <span>·</span>
-                    <span>GIT-NATIVE FLAT FILES</span>
-                    <span>·</span>
-                    <span>EASY SHARING</span>
-                    <span>·</span>
-                    <span>BOSSES LOVE US</span>
-                    <span>·</span>
-                    <span>STORE PHOTOS AND VIDEOS</span>
-                    <span>·</span>
-                    <span>SAVE MONEY</span>
-                    <span>·</span>
-                    <span>GIT-NATIVE FLAT FILES</span>
-                    <span>·</span>
-                    <span>EASY SHARING</span>
-                    <span>·</span>
-                    <span>BOSSES LOVE US</span>
-                    <span>·</span>
-                    <span>STORE PHOTOS AND VIDEOS</span>
-                    <span>·</span>
-                    <span>SAVE MONEY</span>
-                    <span>·</span>
-                    <span>GIT-NATIVE FLAT FILES</span>
-                    <span>·</span>
-                    <span>EASY SHARING</span>
-                    <span>·</span>
-                    <span>BOSSES LOVE US</span>
-                    <span>·</span>
-                    <span>STORE PHOTOS AND VIDEOS</span>
-                    <span>·</span>
-                    <span>SAVE MONEY</span>
-                    <span>·</span>
-                    <span>GIT-NATIVE FLAT FILES</span>
-                    <span>·</span>
-                    <span>EASY SHARING</span>
-                    <span>·</span>
-                    <span>BOSSES LOVE US</span>
-                    <span>·</span>
-                </div>
-            </div>
-        </div>
-    </div>
+<body class="bg-black text-gray-100 sf-pro">
     
     <div class="min-h-screen bg-black px-6 md:px-12">
         <!-- Container -->
@@ -300,7 +238,7 @@
                 <!-- Features Section -->
                 <div class="bg-black py-12 md:py-24 relative">
                     <!-- Title -->
-                    <h2 class="sf-pro text-4xl md:text-5xl lg:text-6xl font-semibold text-gray-200 text-center tracking-tight mb-12 md:mb-16 md:mt-24">
+                    <h2 class="sf-pro text-4xl md:text-5xl lg:text-6xl font-semibold text-gray-200 text-center tracking-tight mb-12 md:mb-16">
                         Why staticDAM?
                     </h2>
                     
@@ -399,12 +337,12 @@
                             <div class="grid grid-cols-1 lg:grid-cols-5 gap-12 lg:gap-16">
                                 <!-- Title Column -->
                                 <div class="lg:sticky lg:top-8 lg:self-start lg:col-span-2">
-                                    <h2 class="sf-pro text-4xl font-semibold tracking-tight text-white sm:text-5xl mt-12 md:mt-24">Frequently asked <br>questions</h2>
+                                    <h2 class="sf-pro text-4xl font-semibold tracking-tight text-white sm:text-5xl mt-12">Frequently asked <br>questions</h2>
                                 </div>
                                 
                                 <!-- FAQ Accordion Column -->
                                 <div class="lg:col-span-3">
-                                    <dl class="divide-y divide-white/10 mt-8 md:mt-24">
+                                    <dl class="divide-y divide-white/10 mt-8">
                                         <div class="py-6 first:pt-0 last:pb-0">
                                             <dt>
                                                 <button type="button" data-faq-button="0" class="flex w-full items-start justify-between text-left text-white">
@@ -690,15 +628,6 @@
     </div>
 
     <script>
-        // Marquee seamless scrolling
-        document.addEventListener('DOMContentLoaded', function() {
-            const marqueeContent = document.querySelector('.marquee-content');
-            const marqueeContainer = document.querySelector('.marquee-container');
-            
-            // Clone the marquee content for seamless loop
-            const clonedContent = marqueeContent.cloneNode(true);
-            marqueeContainer.appendChild(clonedContent);
-        });
         
         // Clean FAQ toggle functionality
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Remove the marquee banner and all associated CSS and JavaScript to simplify the layout.

This PR also adjusts body padding and removes `md:mt-24` classes from the "Why staticDAM?" and FAQ sections, which were previously used to compensate for the fixed marquee bar, ensuring correct spacing after its removal.

---
<a href="https://cursor.com/background-agent?bcId=bc-3eda1266-412e-425a-b0f5-08f0ad31d0d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3eda1266-412e-425a-b0f5-08f0ad31d0d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

