### PR TITLE
Update all fonts to Google Sans Flex

### DIFF
--- a/home.html
+++ b/home.html
@@ -38,9 +38,10 @@
     <meta name="twitter:creator" content="@clarklab">
     <meta name="twitter:site" content="@staticdam">
     
-    <!-- Font Preloading for better performance -->
-    <link rel="preload" href="https://staticdam.com/SF-Pro-Display-Regular.otf" as="font" type="font/otf" crossorigin="anonymous">
-    <link rel="preload" href="https://staticdam.com/SF-Pro-Display-Semibold.otf" as="font" type="font/otf" crossorigin="anonymous">
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@300..700&display=swap" rel="stylesheet">
     
     <!-- Additional SEO -->
     <meta name="theme-color" content="#000000">
@@ -71,57 +72,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
-        
-        /* SF Pro Display Font Faces */
-        @font-face {
-            font-family: 'SF Pro Display';
-            src: url('https://staticdam.com/SF-Pro-Display-Light.otf') format('opentype');
-            font-weight: 300;
-            font-style: normal;
-            font-display: swap;
-        }
-        
-        @font-face {
-            font-family: 'SF Pro Display';
-            src: url('https://staticdam.com/SF-Pro-Display-Regular.otf') format('opentype');
-            font-weight: 400;
-            font-style: normal;
-            font-display: swap;
-        }
-        
-        @font-face {
-            font-family: 'SF Pro Display';
-            src: url('https://staticdam.com/SF-Pro-Display-Medium.otf') format('opentype');
-            font-weight: 500;
-            font-style: normal;
-            font-display: swap;
-        }
-        
-        @font-face {
-            font-family: 'SF Pro Display';
-            src: url('https://staticdam.com/SF-Pro-Display-Semibold.otf') format('opentype');
-            font-weight: 600;
-            font-style: normal;
-            font-display: swap;
-        }
-        
-        @font-face {
-            font-family: 'SF Pro Display';
-            src: url('https://staticdam.com/SF-Pro-Display-Bold.otf') format('opentype');
-            font-weight: 700;
-            font-style: normal;
-            font-display: swap;
-        }
-        
         /* Font Family Classes with System Fallbacks */
-        .sf-pro { 
-            font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; 
+        .sf-pro {
+            font-family: 'Google Sans Flex', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
         }
-        .{ 
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; 
-        }
-        
     </style>
 </head>
 <body class="bg-black text-gray-100 sf-pro">


### PR DESCRIPTION
- Replace self-hosted SF Pro Display fonts with Google Sans Flex
- Use proper Google Fonts embedding with preconnect for performance
- Remove unused Inter font import
- Support font weights 300-700 via variable font